### PR TITLE
Unauthenticated redirect status changed to 302

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -38,7 +38,7 @@ app.get('*', (req, res) => {
     const content = renderer(req, store, context);
 
     if (context.url) {
-      return res.redirect(301, context.url);
+      return res.redirect(302, context.url);
     }
     if (context.notFound) {
       res.status(404);


### PR DESCRIPTION
Hi Stephen,

When I navigated to '/admins' unauthed, the 301 "Moved Permanently" status code was cached by my browser (Chrome). When visiting the route, even after logging in, it would still take me to the cached redirect of '/'. I updated the status to 302, I think this should prevent this.